### PR TITLE
Spark history server is now automatically set up.  Namenode and resource

### DIFF
--- a/bin/impl/fluo_deploy/main.py
+++ b/bin/impl/fluo_deploy/main.py
@@ -253,8 +253,10 @@ def setup_cluster(config):
   sub_d["ZOOKEEPER_HOME"] = config.zookeeper_home()
   sub_d["ZOOKEEPERS"] = config.zookeeper_connect()
   sub_d["ZOOKEEPER_SERVER_CONFIG"] = config.zookeeper_server_config()
-  sub_d["NAMENODE_HOST"] = config.get_service_private_ips("namenode")[0]
-  sub_d["RESOURCEMANAGER_HOST"] = config.get_service_private_ips("resourcemanager")[0]
+  sub_d["NAMENODE_HOST"] = config.get_service_hostnames("namenode")[0]
+  sub_d["NAMENODE_IP"] = config.get_service_private_ips("namenode")[0]
+  sub_d["RESOURCEMANAGER_HOST"] = config.get_service_hostnames("resourcemanager")[0]
+  sub_d["RESOURCEMANAGER_IP"] = config.get_service_private_ips("resourcemanager")[0]
   sub_d["ACCUMULOMASTER_HOST"] = config.get_service_hostnames("accumulomaster")[0]
   sub_d["NUM_WORKERS"] = len(config.get_service_hostnames("worker"))
   sub_d["DATANODE_DIRS"] = config.worker_ephemeral_dirs("/hadoop/data")

--- a/cluster/install/fluo-cluster/bin/impl/init.sh
+++ b/cluster/install/fluo-cluster/bin/impl/init.sh
@@ -49,4 +49,8 @@ echo "Starting accumulo"
 ssh "${SSH_OPTS[@]}" $CLUSTER_USERNAME@$ACCUMULOMASTER_HOST "source $CONF_DIR/env.sh; $ACCUMULO_HOME/bin/accumulo init --clear-instance-name --instance-name $ACCUMULO_INSTANCE --password $ACCUMULO_PASSWORD"
 $BIN_DIR/fluo-cluster start accumulo
 
+echo "Starting spark history server" 
+$HADOOP_PREFIX/bin/hdfs dfs -mkdir -p /spark/history
+$BIN_DIR/fluo-cluster start spark
+
 echo "Cluster initialization is finished"

--- a/cluster/install/fluo-cluster/bin/impl/install.sh
+++ b/cluster/install/fluo-cluster/bin/impl/install.sh
@@ -100,6 +100,8 @@ function install_maven() {
 function install_spark() {
   if [ ! -d "$SPARK_INSTALL" ]; then
     get_install $SPARK_TARBALL
+    cp $CONF_DIR/spark-defaults.conf $SPARK_INSTALL/conf
+    cp $CONF_DIR/spark-env.sh $SPARK_INSTALL/conf
     echo "`hostname`: Spark installed"
   fi
 }

--- a/cluster/install/fluo-cluster/bin/impl/kill-local.sh
+++ b/cluster/install/fluo-cluster/bin/impl/kill-local.sh
@@ -21,4 +21,5 @@ pkill -9 -f QuorumPeerMain
 if rpm -qa | grep -qw docker; then
   sudo docker kill graphite
 fi
+pkill -9 -f org.apache.spark.deploy.history.HistoryServer
 echo "`hostname` - Killed all processes"

--- a/cluster/install/fluo-cluster/bin/impl/setup.sh
+++ b/cluster/install/fluo-cluster/bin/impl/setup.sh
@@ -38,8 +38,8 @@ wget -nc -nv -P $TARBALLS_DIR $APACHE_MIRROR/spark/spark-$SPARK_VERSION/$SPARK_T
 if [[ "$DOWNLOAD_FLUO" = "true" ]]; then
   if [[ "$FLUO_VERSION" =~ "SNAPSHOT" ]]; then
     SONATYPE_URL=https://oss.sonatype.org/content/repositories/snapshots/io/fluo/fluo-distribution/$FLUO_VERSION/
-    FLUO_TARBALL_URL=`curl -s $SONATYPE_URL | grep 'bin.tar.gz"' | cut -d'"' -f 2`
-    FLUO_MD5_URL=`curl -s $SONATYPE_URL | grep 'bin.tar.gz.md5"' | cut -d'"' -f 2`
+    FLUO_TARBALL_URL=`curl -s $SONATYPE_URL | grep 'bin.tar.gz"' | tail -1 | cut -d'"' -f 2`
+    FLUO_MD5_URL=`curl -s $SONATYPE_URL | grep 'bin.tar.gz.md5"' | tail -1 | cut -d'"' -f 2`
   else
     SONATYPE_URL=https://repo1.maven.org/maven2/io/fluo/fluo-distribution/$FLUO_VERSION
     FLUO_TARBALL_URL=$SONATYPE_URL/fluo-distribution-$FLUO_VERSION-bin.tar.gz

--- a/cluster/install/fluo-cluster/bin/impl/start.sh
+++ b/cluster/install/fluo-cluster/bin/impl/start.sh
@@ -32,6 +32,10 @@ accumulo)
   ssh "${SSH_OPTS[@]}" $CLUSTER_USERNAME@$ACCUMULOMASTER_HOST $ACCUMULO_HOME/bin/start-all.sh
   echo "$ACCUMULOMASTER_HOST: Accumulo started"
   ;;
+spark)
+  ssh "${SSH_OPTS[@]}" $CLUSTER_USERNAME@$RESOURCEMANAGER_HOST $SPARK_INSTALL/sbin/start-history-server.sh
+  echo "$RESOURCEMANAGER_HOST: Spark HistoryServer started"
+  ;;
 *)
   echo -e "Usage: fluo-cluster start <argument>\n"
   echo -e "Possible arguments:\n"

--- a/cluster/install/fluo-cluster/conf/.gitignore
+++ b/cluster/install/fluo-cluster/conf/.gitignore
@@ -13,3 +13,5 @@ keys
 metrics.yaml
 apps.properties
 awscreds.conf
+spark-defaults.conf
+spark-env.sh

--- a/cluster/templates/fluo-cluster/conf/accumulo-site.xml
+++ b/cluster/templates/fluo-cluster/conf/accumulo-site.xml
@@ -4,7 +4,7 @@
 <configuration>
   <property>
     <name>instance.volumes</name>
-    <value>hdfs://$NAMENODE_HOST:10000/accumulo</value>
+    <value>hdfs://$NAMENODE_IP:10000/accumulo</value>
   </property>
 
   <property>

--- a/cluster/templates/fluo-cluster/conf/core-site.xml
+++ b/cluster/templates/fluo-cluster/conf/core-site.xml
@@ -19,6 +19,6 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name> 
-    <value>hdfs://$NAMENODE_HOST:10000</value>
+    <value>hdfs://$NAMENODE_IP:10000</value>
   </property>
 </configuration>

--- a/cluster/templates/fluo-cluster/conf/fluo.properties
+++ b/cluster/templates/fluo-cluster/conf/fluo.properties
@@ -50,7 +50,7 @@ io.fluo.client.accumulo.zookeepers=$ZOOKEEPERS
 # Accumulo table to initialize
 io.fluo.admin.accumulo.table=$${io.fluo.client.application.name}
 # HDFS root path. Should match 'fs.defaultFS' property in Hadoop's core-site.xml
-io.fluo.admin.hdfs.root=hdfs://$NAMENODE_HOST:10000
+io.fluo.admin.hdfs.root=hdfs://$NAMENODE_IP:10000
 # Fluo uses iterators within Accumulo tablet servers, therefore Accumulo per
 # table classpath need to be configured with a comma seperated list of uris
 # where Accumulo can find Fluo jars.  These jars should be reachable from

--- a/cluster/templates/fluo-cluster/conf/hdfs-site.xml
+++ b/cluster/templates/fluo-cluster/conf/hdfs-site.xml
@@ -31,10 +31,10 @@
   </property>
   <property>
     <name>dfs.namenode.secondary.http-address</name>
-    <value>$NAMENODE_HOST:50090</value>
+    <value>$NAMENODE_IP:50090</value>
   </property>
   <property>
     <name>dfs.namenode.secondary.https-address</name>
-    <value>$NAMENODE_HOST:50091</value>
+    <value>$NAMENODE_IP:50091</value>
   </property>
 </configuration>

--- a/cluster/templates/fluo-cluster/conf/spark-defaults.conf
+++ b/cluster/templates/fluo-cluster/conf/spark-defaults.conf
@@ -1,0 +1,6 @@
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+spark.eventLog.enabled             true
+spark.eventLog.dir                 hdfs://$NAMENODE_IP:10000/spark/history
+spark.history.fs.logDirectory      hdfs://$NAMENODE_IP:10000/spark/history
+spark.yarn.historyServer.address   $RESOURCEMANAGER_HOST:18080

--- a/cluster/templates/fluo-cluster/conf/spark-env.sh
+++ b/cluster/templates/fluo-cluster/conf/spark-env.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+HADOOP_CONF_DIR=$HADOOP_PREFIX/etc/hadoop

--- a/cluster/templates/fluo-cluster/conf/yarn-site.xml
+++ b/cluster/templates/fluo-cluster/conf/yarn-site.xml
@@ -19,7 +19,7 @@
 <configuration>
   <property>
     <name>yarn.resourcemanager.hostname</name>
-    <value>$RESOURCEMANAGER_HOST</value>
+    <value>$RESOURCEMANAGER_IP</value>
   </property>
   <property>
     <name>yarn.nodemanager.local-dirs</name>


### PR DESCRIPTION
manager now configured using hostname rather than private ip. Changed
fluo snaphot download to pull down most recent tarball (which is last
one listed on page).  Configured HADOOP_CONF_DIR for spark-submit.